### PR TITLE
docs: remover cheatsheet de cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,6 @@ Este projeto foi desenvolvido pelos estudantes:
 - Página de edição de usuários.
 - Dashboard (homepage).
 
-
-
-## Documentação de cores
-
-| Cor               | Hexadecimal                                                |
-| ----------------- | ---------------------------------------------------------------- |
-| Inputs            | ![#198754](https://via.placeholder.com/10/198754?text=+) #198754 |
-| Buttons           | ![#031806](https://via.placeholder.com/10/031806?text=+) #031806 |
-| Pop-up            | ![#a3cfbb](https://via.placeholder.com/10/a3cfbb?text=+) #a3cfbb |
-
-
 ## Diagrama de Caso de Uso
 <img src="assets/img/casouso.jpg" alt="Diagrama de Caso de Uso">
 


### PR DESCRIPTION
uma tabela de cores hexadecimais não é relevante no contexto de documentação de um projeto

pode ser relevante uma [paleta de cores](https://github.com/user-attachments/assets/7e33850e-f1c2-4737-94e2-3feb51a8ff8e) acompanhado de uma explicação da razão por ter sido escolhida
